### PR TITLE
Minor Fixes

### DIFF
--- a/pymic/offload_library.py
+++ b/pymic/offload_library.py
@@ -65,19 +65,19 @@ class OffloadLibrary:
 
     @staticmethod
     def _find_library(library):
-        if os.path.isabs(library):
+        if os.path.isabs(library) and OffloadLibrary._check_k1om(abspath):
             abspath = library
         else:
             for path in config._search_path.split(':'):
                 abspath = os.path.join(path, library)
 
-                if os.path.isfile(abspath):
+                if (os.path.isfile(abspath) and
+                    OffloadLibrary._check_k1om(abspath)):
                     break
             else:
                 return
 
-        if OffloadLibrary._check_k1om(abspath):
-            return abspath
+        return abspath
 
     def __init__(self, library, device=None):
         """Initialize this OffloadLibrary instance.  This function is not to be

--- a/pymic/offload_library.py
+++ b/pymic/offload_library.py
@@ -129,4 +129,5 @@ class OffloadLibrary:
             funcptr = _pymic_impl_find_kernel(self._device_id,
                                               self._handle, attr)
             self._cache[attr] = funcptr
-        return (attr, funcptr, self._device)
+
+        return attr, funcptr, self._device, self

--- a/pymic/offload_library.py
+++ b/pymic/offload_library.py
@@ -65,16 +65,19 @@ class OffloadLibrary:
 
     @staticmethod
     def _find_library(library):
-        for path in config._search_path.split(":"):
-            try:
-                files = [f for f in os.listdir(path)
-                         if os.path.isfile(os.path.join(path, f))]
-                if library in files:
-                    filename = os.path.join(path, library)
-                    if OffloadLibrary._check_k1om(filename):
-                        return filename
-            except:
-                pass
+        if os.path.isabs(library):
+            abspath = library
+        else:
+            for path in config._search_path.split(':'):
+                abspath = os.path.join(path, library)
+
+                if os.path.isfile(abspath):
+                    break
+            else:
+                return
+
+        if OffloadLibrary._check_k1om(abspath):
+            return abspath
 
     def __init__(self, library, device=None):
         """Initialize this OffloadLibrary instance.  This function is not to be


### PR DESCRIPTION
These two commits allow for the use of absolute paths when loading a library and also prevent a crash that can be caused when one does: ```foo = dev.load_library(lib).foo```.