### PR TITLE
Switch from FakePointer to DeviceAllocation

### DIFF
--- a/pymic/_misc.py
+++ b/pymic/_misc.py
@@ -1,31 +1,31 @@
-# Copyright (c) 2014-2015, Intel Corporation All rights reserved. 
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions are 
-# met: 
-# 
-# 1. Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer. 
+# Copyright (c) 2014-2015, Intel Corporation All rights reserved.
 #
-# 2. Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in the 
-# documentation and/or other materials provided with the distribution. 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
 #
-# 3. Neither the name of the copyright holder nor the names of its 
-# contributors may be used to endorse or promote products derived from 
-# this software without specific prior written permission. 
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
-# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
-# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
-# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
 
@@ -44,7 +44,7 @@ class pymicConfig:
             self._debug_level = int(_debug_level)
         except:
             pass
-            
+
         # PYMIC_TRACE
         self._trace_level = 0
         _trace_level = os.getenv("PYMIC_TRACE", 0)
@@ -60,13 +60,13 @@ class pymicConfig:
         # PYMIC_LIBRARY_PATH
         self._search_path = os.getenv("PYMIC_LIBRARY_PATH", "")
 
-        
+
 _config = pymicConfig()
 
 
 # determine the integer value for PYMIC_DEBUG
 if _config._debug_level is not None:
-    print("PYMIC: debug level set to {0}".format(_config._debug_level), 
+    print("PYMIC: debug level set to {0}".format(_config._debug_level),
           file=sys.stderr)
 
 
@@ -76,7 +76,7 @@ def _debug(level, format, *objs):
         print(msg, file=sys.stderr)
     return None
 
-    
+
 def _deprecated(func):
     def wrapper(*args):
         print("Warning: function '{0}' has been "
@@ -84,7 +84,7 @@ def _deprecated(func):
         func(*args)
     return wrapper
 
-    
+
 def _get_order(array):
     """Determine the storage order of an array and map it to its string
        representation.
@@ -102,7 +102,7 @@ _data_type_map = {
     # Python types
     int: 0,
     float: 1,
-    complex: 2, 
+    complex: 2,
 
     # Numpy dtypes
     numpy.dtype(numpy.int64): 0,
@@ -118,17 +118,17 @@ def _map_data_types(dtype):
     return _data_type_map[dtype]
 
 
-class _FakePointer:
+class _DeviceAllocation:
     """Smart pointer to store the fake pointer and perform pointer
        translation and offset computation."""
-       
+
     _stream = None
     _device_id = None
     _device_ptr = None
     _sticky = False
     _allocated = False
     _offset = 0
-       
+
     def __init__(self, stream, device, device_ptr, sticky):
         """Initialize the fake pointer with the data coming from
            OffloadStream.allocate_device_memory."""
@@ -139,20 +139,20 @@ class _FakePointer:
         self._device = device
         self._device_ptr = device_ptr
         self._sticky = sticky
-    
-    def __str__(self): 
+
+    def __str__(self):
         """Pretty print the value of this fake pointer."""
         return '0x{0:x}+{1}'.format(self._device_ptr, self._offset)
-    
+
     def __del__(self):
         if self._allocated and not self._sticky:
             self._stream.deallocate_device_memory(self)
-    
+
     def __add__(self, offset):
         """Add an offset to the fake pointer."""
         if not isinstance(offset, int):
             raise ValueError('Only int offsets allowed for fake pointers.')
-        new = _FakePointer(self._stream, self._device, self._device_ptr, 
+        new = _DeviceAllocation(self._stream, self._device, self._device_ptr,
                            self._sticky)
         new._offset = self._offset + offset
         return new
@@ -163,12 +163,12 @@ class _FakePointer:
             raise ValueError('Only int offsets allowed for fake pointers.')
         self._offset += offset
         return self
-    
+
     def __sub__(self, offset):
         """Substract an offset to the fake pointer."""
         if not isinstance(offset, int):
             raise ValueError('Only int offsets allowed for fake pointers.')
-        new = _FakePointer(self._stream, self._device, self._device_ptr, 
+        new = _DeviceAllocation(self._stream, self._device, self._device_ptr,
                            self._sticky)
         new._offset = self._offset - offset
         return new

--- a/pymic/_misc.py
+++ b/pymic/_misc.py
@@ -127,7 +127,6 @@ class _DeviceAllocation:
     _device_ptr = None
     _sticky = False
     _allocated = False
-    _offset = 0
 
     def __init__(self, stream, device, device_ptr, sticky):
         """Initialize the fake pointer with the data coming from
@@ -142,7 +141,7 @@ class _DeviceAllocation:
 
     def __str__(self):
         """Pretty print the value of this fake pointer."""
-        return '0x{0:x}+{1}'.format(self._device_ptr, self._offset)
+        return '0x{0:x}'.format(self._device_ptr)
 
     def __del__(self):
         if self._allocated and not self._sticky:

--- a/pymic/_misc.py
+++ b/pymic/_misc.py
@@ -147,35 +147,3 @@ class _DeviceAllocation:
     def __del__(self):
         if self._allocated and not self._sticky:
             self._stream.deallocate_device_memory(self)
-
-    def __add__(self, offset):
-        """Add an offset to the fake pointer."""
-        if not isinstance(offset, int):
-            raise ValueError('Only int offsets allowed for fake pointers.')
-        new = _DeviceAllocation(self._stream, self._device, self._device_ptr,
-                           self._sticky)
-        new._offset = self._offset + offset
-        return new
-
-    def __iadd__(self, offset):
-        """And an offset to the fake pointer (in-place operation)."""
-        if not isinstance(offset, int):
-            raise ValueError('Only int offsets allowed for fake pointers.')
-        self._offset += offset
-        return self
-
-    def __sub__(self, offset):
-        """Substract an offset to the fake pointer."""
-        if not isinstance(offset, int):
-            raise ValueError('Only int offsets allowed for fake pointers.')
-        new = _DeviceAllocation(self._stream, self._device, self._device_ptr,
-                           self._sticky)
-        new._offset = self._offset - offset
-        return new
-
-    def __isub__(self):
-        """Substract an offset to the fake pointer (in-place operation)."""
-        if not isinstance(offset, int):
-            raise ValueError('Only int offsets allowed for fake pointers.')
-        self._offset -= offset
-        return self

--- a/pymic/_misc.py
+++ b/pymic/_misc.py
@@ -121,18 +121,13 @@ def _map_data_types(dtype):
 class _DeviceAllocation:
     """Smart pointer to store the fake pointer and perform pointer
        translation and offset computation."""
-
-    _stream = None
-    _device_id = None
-    _device_ptr = None
-    _sticky = False
-
     def __init__(self, stream, device, device_ptr, sticky):
         """Initialize the fake pointer with the data coming from
            OffloadStream.allocate_device_memory."""
         assert stream != None
         assert device != None
         assert device_ptr != None
+
         self._stream = stream
         self._device = device
         self._device_ptr = device_ptr

--- a/pymic/_misc.py
+++ b/pymic/_misc.py
@@ -126,7 +126,6 @@ class _DeviceAllocation:
     _device_id = None
     _device_ptr = None
     _sticky = False
-    _allocated = False
 
     def __init__(self, stream, device, device_ptr, sticky):
         """Initialize the fake pointer with the data coming from
@@ -144,5 +143,5 @@ class _DeviceAllocation:
         return '0x{0:x}'.format(self._device_ptr)
 
     def __del__(self):
-        if self._allocated and not self._sticky:
+        if not self._sticky:
             self._stream.deallocate_device_memory(self)

--- a/pymic/offload_stream.py
+++ b/pymic/offload_stream.py
@@ -623,12 +623,9 @@ class OffloadStream:
         pymic_stream_invoke_kernel(self._device_id, self._stream_id, kernel[1],
                                    len(args), arg_dims, arg_type, arg_ptrs,
                                    arg_size)
-        # iterate over the copyout arguments, transfer them back,
-        # and release buffers
+        # iterate over the copyout arguments, transfer them back
         for c in copy_in_out:
             self.transfer_device2host(c[1], c[0], c[2])
-            self.deallocate_device_memory(c[1])
-        return None
 
     @trace
     def bind(self, array, update_device=True):

--- a/pymic/offload_stream.py
+++ b/pymic/offload_stream.py
@@ -275,11 +275,6 @@ class OffloadStream:
             raise ValueError('Invalid None host pointer')
         if nbytes <= 0:
             raise ValueError('Invalid byte count: {0}'.format(nbytes))
-        if device_ptr._offset != 0:
-            if offset_device != 0:
-                raise ValueError('Offset cannot be non-zero if fake pointer'
-                                 'has an offset.')
-            offset_device = device_ptr._offset
 
         debug(1, '(host -> device {0}) transferring {1} bytes '
                  '(host ptr 0x{2:x}, device ptr {3}',
@@ -362,11 +357,6 @@ class OffloadStream:
             raise ValueError('Invalid None host pointer')
         if nbytes <= 0:
             raise ValueError('Invalid byte count: {0}'.format(nbytes))
-        if device_ptr._offset != 0:
-            if offset_device != 0:
-                raise ValueError('Offset cannot be non-zero if fake pointer'
-                                 'has an offset.')
-            offset_device = device_ptr._offset
 
         debug(1, '(device {0} -> host) transferring {1} bytes '
                  '(device ptr {2}, host ptr 0x{3:x})',

--- a/pymic/offload_stream.py
+++ b/pymic/offload_stream.py
@@ -495,9 +495,10 @@ class OffloadStream:
         if device_ptr is None:
             return 0
 
-        if device_ptr._device_id != self._device_id:
+        device_id = device_ptr._stream._device_id
+        if device_id != self._device_id:
             raise OffloadError('Device pointer for device {0} does not belong '
-                               'to device {1}.'.format(device_ptr._device,
+                               'to device {1}.'.format(device_id,
                                                        self._device_id))
 
         ptr = device_ptr._device_ptr
@@ -508,7 +509,7 @@ class OffloadStream:
         offl_translated.update_host()
         self.sync()
 
-        return translated[0]
+        return int(translated[0])
 
     @trace
     def invoke(self, kernel, *args):

--- a/pymic/offload_stream.py
+++ b/pymic/offload_stream.py
@@ -1,31 +1,31 @@
-# Copyright (c) 2014-2015, Intel Corporation All rights reserved. 
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions are 
-# met: 
-# 
-# 1. Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer. 
+# Copyright (c) 2014-2015, Intel Corporation All rights reserved.
 #
-# 2. Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in the 
-# documentation and/or other materials provided with the distribution. 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
 #
-# 3. Neither the name of the copyright holder nor the names of its 
-# contributors may be used to endorse or promote products derived from 
-# this software without specific prior written permission. 
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
 #
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
-# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
-# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
-# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
-# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from __future__ import print_function
 
@@ -45,7 +45,7 @@ from pymic_libxstream import pymic_stream_invoke_kernel
 
 from _misc import _debug as debug
 from _misc import _get_order as get_order
-from _misc import _FakePointer as FakePointer
+from _misc import _DeviceAllocation as DeviceAllocation
 from _misc import _map_data_types as map_data_types
 from _tracing import _trace as trace
 
@@ -68,17 +68,17 @@ class OffloadStream:
 
         # construct the stream
         self._stream_id = pymic_stream_create(self._device_id, 'stream')
-        debug(1, 
+        debug(1,
               'created stream 0x{0:x} for device {1}'.format(self._stream_id,
                                                              self._device_id))
-        
+
     def __del__(self):
-        debug(1, 
+        debug(1,
               'destroying stream 0x{0:0x} '
               'for device {1}'.format(self._stream_id,
                                       self._device_id))
         pymic_stream_destroy(self._device_id, self._stream_id)
-    
+
     @trace
     def sync(self):
         """Wait for all outstanding requests in this OffloadStream to complete.
@@ -92,7 +92,7 @@ class OffloadStream:
            Returns
            -------
            n/a
-           
+
            See Also
            --------
            n/a
@@ -101,11 +101,11 @@ class OffloadStream:
         return None
 
     def __eq__(self, other):
-        return (self._device == other.device and 
+        return (self._device == other.device and
                 self._stream_id == other.stream_id)
 
     def __repr__(self):
-        return "OffloadStream({0}) for {1}".format(self._stream_id, 
+        return "OffloadStream({0}) for {1}".format(self._stream_id,
                                                    self._device.__repr__())
 
     def __str__(self):
@@ -114,22 +114,22 @@ class OffloadStream:
     def allocate_device_memory(self, nbytes, alignment=64, sticky=False):
         """Allocate device memory on device associated with the invoking
            stream object.  Though it is part of the stream interface,
-           the operation is synchronous.  
-           
+           the operation is synchronous.
+
            Caution: this is a low-level function, do not use it unless you
-                    have a very specific reason to do so.  Better use the 
+                    have a very specific reason to do so.  Better use the
                     high-level interfaces of OffloadArray instead.
-           
+
            Parameters
            ----------
            nbytes : int
               Number of bytes to allocate
            alignment : int
               Alignment of the data on the target device.
-           
+
            See Also
            --------
-           deallocate_device_memory, transfer_host2device, 
+           deallocate_device_memory, transfer_host2device,
            transfer_device2host, transfer_device2device
 
            Returns
@@ -143,94 +143,94 @@ class OffloadStream:
            >>> print ptr
            140297169571840
         """
-    
+
         device = self._device_id
-    
+
         if nbytes <= 0:
             raise ValueError('Cannot allocate negative amount of '
                              'memory: {0}'.format(nbytes))
-        
+
         device_ptr = pymic_stream_allocate(device, self._stream_id,
                                            nbytes, alignment)
-        device_ptr = FakePointer(self, device, device_ptr, sticky)                                    
+        device_ptr = DeviceAllocation(self, device, device_ptr, sticky)
         debug(2, 'allocated {0} bytes on device {1} at {2}'
-                 ', alignment {3}', 
+                 ', alignment {3}',
                  nbytes, device, device_ptr, alignment)
         return device_ptr
-        
+
     def deallocate_device_memory(self, device_ptr):
         """Deallocate device memory previously allocated through
-           allocate_device_memory.  Though it is part of the stream 
-           interface, the operation is synchronous. 
-           
+           allocate_device_memory.  Though it is part of the stream
+           interface, the operation is synchronous.
+
            Caution: this is a low-level function, do not use it unless you
-                    have a very specific reason to do so.  Better use the 
+                    have a very specific reason to do so.  Better use the
                     high-level interfaces of OffloadArray instead.
-           
+
            Parameters
            ----------
            device_ptr : int
               Fake pointer of memory do deallocate
-           
+
            See Also
            --------
-           allocate_device_memory, transfer_host2device, 
+           allocate_device_memory, transfer_host2device,
            transfer_device2host, transfer_device2device
 
            Returns
            -------
            None
-           
+
            Examples
            --------
            >>> ptr = stream.allocate_device_memory(4096)
            >>> stream.deallocate_device_memory(ptr)
         """
-        
+
         device = self._device
-    
+
         if device_ptr is None:
             raise ValueError('Cannot deallocate None pointer')
-        if not isinstance(device_ptr, FakePointer):
+        if not isinstance(device_ptr, DeviceAllocation):
             raise ValueError('Wrong argument, no device pointer given')
-        # TODO: add more safety checks here (e.g., pointer from right device 
+        # TODO: add more safety checks here (e.g., pointer from right device
         #       and stream)
-        
-        pymic_stream_deallocate(self._device_id, self._stream_id, 
+
+        pymic_stream_deallocate(self._device_id, self._stream_id,
                                 device_ptr._device_ptr)
         debug(2, 'deallocated pointer {0} on device {1}',
                  device_ptr, device)
-        
+
         return None
-        
-    def transfer_host2device(self, host_ptr, device_ptr, 
+
+    def transfer_host2device(self, host_ptr, device_ptr,
                              nbytes, offset_host=0, offset_device=0):
         """Transfer data from a host memory location (identified by its
-           raw pointer (i.e., a C pointer) to a memory region (identified 
-           by its fake pointer) on the target device.  The operation is 
+           raw pointer (i.e., a C pointer) to a memory region (identified
+           by its fake pointer) on the target device.  The operation is
            executed asynchronously with stream semantics.
-           
+
            Caution: this is a low-level function, do not use it unless you
-                    have a very specific reason to do so.  Better use the 
+                    have a very specific reason to do so.  Better use the
                     high-level interfaces of OffloadArray instead.
-           
+
            Parameters
            ----------
            host_ptr : int
               Pointer to the data on the host
-           device_ptr : int 
+           device_ptr : int
               Fake pointer of the destination
-           nbytes : int 
+           nbytes : int
               Number of bytes to copy
            offset_host : int, optional, default 0
               Transfer offset (bytes) to be added to raw host pointer
            offset_device : int, optional, default 0
               Transfer offset (bytes) to be added to the address of the device
               memory.
-           
+
            See Also
            --------
-           transfer_device2host, transfer_device2device, 
+           transfer_device2host, transfer_device2device,
            allocate_device_memory, deallocate_device_memory
 
            Returns
@@ -246,24 +246,24 @@ class OffloadStream:
            >>> stream.transfer_host2device(ptr_a_host, device_ptr, nbytes)
            >>> b = numpy.empty_like(a)
            >>> print b
-           [  6.90762927e-310   7.73120247e-317   3.60667921e-322   
-              0.00000000e+000   0.00000000e+000   0.00000000e+000   
-              0.00000000e+000   0.00000000e+000   4.94065646e-324   
+           [  6.90762927e-310   7.73120247e-317   3.60667921e-322
+              0.00000000e+000   0.00000000e+000   0.00000000e+000
+              0.00000000e+000   0.00000000e+000   4.94065646e-324
               9.76815212e-317   7.98912845e-317   0.00000000e+000
-              5.53353523e-322   1.58101007e-322   0.00000000e+000   
+              5.53353523e-322   1.58101007e-322   0.00000000e+000
               7.38839996e-317]
            # random data
            >>> ptr_b_host = b.ctypes.data
            >>> stream.transfer_device2host(device_ptr, ptr_b_host, nbytes)
            >>> stream.sync()
            >>> print b
-           [  0.   1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  
+           [  0.   1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.
              12.  13.  14.  15.]
         """
 
-        if not isinstance(device_ptr, FakePointer):
+        if not isinstance(device_ptr, DeviceAllocation):
             raise ValueError('Wrong argument, no device pointer given')
-        # TODO: add more safety checks here (e.g., pointer from right device 
+        # TODO: add more safety checks here (e.g., pointer from right device
         #       and stream)
         if offset_host < 0:
             raise ValueError("Negative offset passed for offset_host")
@@ -280,41 +280,41 @@ class OffloadStream:
                 raise ValueError('Offset cannot be non-zero if fake pointer'
                                  'has an offset.')
             offset_device = device_ptr._offset
-            
+
         debug(1, '(host -> device {0}) transferring {1} bytes '
-                 '(host ptr 0x{2:x}, device ptr {3}', 
+                 '(host ptr 0x{2:x}, device ptr {3}',
                  self._device_id, nbytes, host_ptr, device_ptr)
         device_ptr = device_ptr._device_ptr
-        pymic_stream_memcpy_h2d(self._device_id, self._stream_id, 
-                                host_ptr, device_ptr, 
+        pymic_stream_memcpy_h2d(self._device_id, self._stream_id,
+                                host_ptr, device_ptr,
                                 nbytes, offset_host, offset_device)
         return None
 
-    def transfer_device2host(self, device_ptr, host_ptr, 
+    def transfer_device2host(self, device_ptr, host_ptr,
                              nbytes, offset_device=0, offset_host=0):
-        """Transfer data from a device memory location (identified by its 
-           fake pointer) to a host memory region identified by its raw pointer 
-           (i.e., a C pointer)on the target device. The operation is executed 
+        """Transfer data from a device memory location (identified by its
+           fake pointer) to a host memory region identified by its raw pointer
+           (i.e., a C pointer)on the target device. The operation is executed
            asynchronously with stream semantics.
-           
+
            Caution: this is a low-level function, do not use it unless you
-                    have a very specific reason to do so.  Better use the 
+                    have a very specific reason to do so.  Better use the
                     high-level interfaces of OffloadArray instead.
-           
+
            Parameters
            ----------
            host_ptr : int
               Pointer to the data on the host
-           device_ptr : int 
+           device_ptr : int
               Fake pointer of the destination
-           nbytes : int 
+           nbytes : int
               Number of bytes to copy
            offset_device : int, optional, default 0
               Transfer offset (bytes) to be added to the address of the device
               memory.
            offset_host : int, optional, default 0
               Transfer offset (bytes) to be added to raw host pointer
-           
+
            See Also
            --------
            transfer_host2device, transfer_device2device,
@@ -333,24 +333,24 @@ class OffloadStream:
            >>> stream.transfer_host2device(ptr_a_host, device_ptr, nbytes)
            >>> b = numpy.empty_like(a)
            >>> print b
-           [  6.90762927e-310   7.73120247e-317   3.60667921e-322   
-              0.00000000e+000   0.00000000e+000   0.00000000e+000   
-              0.00000000e+000   0.00000000e+000   4.94065646e-324   
+           [  6.90762927e-310   7.73120247e-317   3.60667921e-322
+              0.00000000e+000   0.00000000e+000   0.00000000e+000
+              0.00000000e+000   0.00000000e+000   4.94065646e-324
               9.76815212e-317   7.98912845e-317   0.00000000e+000
-              5.53353523e-322   1.58101007e-322   0.00000000e+000   
+              5.53353523e-322   1.58101007e-322   0.00000000e+000
               7.38839996e-317]
            # random data
            >>> ptr_b_host = b.ctypes.data
            >>> stream.transfer_device2host(device_ptr, ptr_b_host, nbytes)
            >>> stream.sync()
            >>> print b
-           [  0.   1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  
+           [  0.   1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.
              12.  13.  14.  15.]
         """
 
-        if not isinstance(device_ptr, FakePointer):
+        if not isinstance(device_ptr, DeviceAllocation):
             raise ValueError('Wrong argument, no device pointer given')
-        # TODO: add more safety checks here (e.g., pointer from right device 
+        # TODO: add more safety checks here (e.g., pointer from right device
         #       and stream)
         if offset_device < 0:
             raise ValueError("Negative offset passed for offset_device")
@@ -367,34 +367,34 @@ class OffloadStream:
                 raise ValueError('Offset cannot be non-zero if fake pointer'
                                  'has an offset.')
             offset_device = device_ptr._offset
-            
+
         debug(1, '(device {0} -> host) transferring {1} bytes '
-                 '(device ptr {2}, host ptr 0x{3:x})', 
+                 '(device ptr {2}, host ptr 0x{3:x})',
                  self._device_id, nbytes, device_ptr, host_ptr)
         device_ptr = device_ptr._device_ptr
-        pymic_stream_memcpy_d2h(self._device_id, self._stream_id, 
-                                device_ptr, host_ptr, 
+        pymic_stream_memcpy_d2h(self._device_id, self._stream_id,
+                                device_ptr, host_ptr,
                                 nbytes, offset_device, offset_host)
         return None
 
-    def transfer_device2device(self, device_ptr_src, device_ptr_dst, 
-                               nbytes, offset_device_src=0, 
+    def transfer_device2device(self, device_ptr_src, device_ptr_dst,
+                               nbytes, offset_device_src=0,
                                offset_device_dst=0):
-        """Transfer data from a device memory location (identified by its 
-           fake pointer) to another memory region on the same device. The 
+        """Transfer data from a device memory location (identified by its
+           fake pointer) to another memory region on the same device. The
            operation is executed asynchronously with stream semantics.
-           
+
            Caution: this is a low-level function, do not use it unless you
-                    have a very specific reason to do so.  Better use the 
+                    have a very specific reason to do so.  Better use the
                     high-level interfaces of OffloadArray instead.
-           
+
            Parameters
            ----------
            device_ptr_src : int
               Fake pointer to the source memory location
-           device_ptr_dst : int 
+           device_ptr_dst : int
               Fake pointer to the destination memory location
-           nbytes : int 
+           nbytes : int
               Number of bytes to copy
            offset_device_src : int, optional, default 0
               Transfer offset (bytes) to be added to the address of the device
@@ -402,10 +402,10 @@ class OffloadStream:
            offset_device_dst : int, optional, default 0
               Transfer offset (bytes) to be added to the address of the device
               memory (destination).
-           
+
            See Also
            --------
-           transfer_host2device, allocate_device_memory, 
+           transfer_host2device, allocate_device_memory,
            deallocate_device_memory
 
            Returns
@@ -420,32 +420,32 @@ class OffloadStream:
            >>> device_ptr_1 = stream.allocate_device_memory(nbytes)
            >>> stream.transfer_host2device(ptr_a_host, device_ptr_1, nbytes)
            >>> device_ptr_2 = stream.allocate_device_memory(nbytes)
-           >>> stream.transfer_device2device(device_ptr_1, device_ptr_2, 
+           >>> stream.transfer_device2device(device_ptr_1, device_ptr_2,
                                              nbytes)
            >>> b = numpy.empty_like(a)
-           [  6.95303066e-310   6.83874600e-317   3.95252517e-322   
-              0.00000000e+000   9.31741387e+242   0.00000000e+000   
-              0.00000000e+000   0.00000000e+000   4.94065646e-324   
+           [  6.95303066e-310   6.83874600e-317   3.95252517e-322
+              0.00000000e+000   9.31741387e+242   0.00000000e+000
+              0.00000000e+000   0.00000000e+000   4.94065646e-324
               3.30519641e-317   1.72409659e+212   1.20070123e-089
-              5.05907223e-085   4.87883721e+199   0.00000000e+000   
-              6.78545805e-317] 
+              5.05907223e-085   4.87883721e+199   0.00000000e+000
+              6.78545805e-317]
            # random data
            >>> print b
            >>> ptr_b_host = b.ctypes.data
            >>> stream.transfer_device2host(device_ptr_2, ptr_b_host, nbytes)
            >>> stream.sync()
            >>> print b
-           [  0.   1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.  
+           [  0.   1.   2.   3.   4.   5.   6.   7.   8.   9.  10.  11.
              12.  13.  14.  15.]
         """
 
-        if not isinstance(device_ptr_src, FakePointer):
+        if not isinstance(device_ptr_src, DeviceAllocation):
             raise ValueError('Wrong argument, no device pointer given')
-        # TODO: add more safety checks here (e.g., pointer from right device 
+        # TODO: add more safety checks here (e.g., pointer from right device
         #       and stream)
-        if not isinstance(device_ptr_dst, FakePointer):
+        if not isinstance(device_ptr_dst, DeviceAllocation):
             raise ValueError('Wrong argument, no device pointer given')
-        # TODO: add more safety checks here (e.g., pointer from right device 
+        # TODO: add more safety checks here (e.g., pointer from right device
         #       and stream)
         if offset_device_src < 0:
             raise ValueError("Negative offset passed for offset_device_src")
@@ -457,18 +457,18 @@ class OffloadStream:
             raise ValueError('Invalid None host pointer')
         if nbytes <= 0:
             raise ValueError('Invalid byte count: {0}'.format(nbytes))
-        
+
         device_ptr_src = device_ptr_src._device_ptr
         device_ptr_dst = device_ptr_dst._device_ptr
         debug(1, '(device {0} -> device {0}) transferring {1} bytes '
-                 '(source ptr {2}, destination ptr {3})', 
+                 '(source ptr {2}, destination ptr {3})',
                  self._device_id, nbytes, device_ptr_src, device_ptr_dst)
-        pymic_stream_memcpy_d2d(self._device_id, self._stream_id, 
-                                device_ptr_src, device_ptr_dst, 
-                                nbytes, offset_device_src, 
+        pymic_stream_memcpy_d2d(self._device_id, self._stream_id,
+                                device_ptr_src, device_ptr_dst,
+                                nbytes, offset_device_src,
                                 offset_device_dst)
         return None
-            
+
     def translate_device_pointer(self, device_ptr):
         """Translate a fake pointer to a real raw pointer on the target device.
            Though it is part of the stream interface, the operation is
@@ -501,32 +501,32 @@ class OffloadStream:
            >>> print translated
            140702047573768     # random data
         """
-        
+
         if device_ptr is None:
             return 0
-        
+
         if device_ptr._device_id != self._device_id:
             raise OffloadError('Device pointer for device {0} does not belong '
                                'to device {1}.'.format(device_ptr._device,
                                                        self._device_id))
-              
+
         ptr = device_ptr._device_ptr
         translated = numpy.zeros((1,), dtype=int)
         offl_translated = self.bind(translated, update_device=False)
-        self.invoke(offl_translated._library.pymic_translate_pointer, 
+        self.invoke(offl_translated._library.pymic_translate_pointer,
                     ptr, offl_translated)
         offl_translated.update_host()
         self.sync()
-                
+
         return translated[0]
-        
+
     @trace
     def invoke(self, kernel, *args):
         """Invoke a native kernel on the target device by enqueuing a request
-           in the current stream.  The kernel is identified by accessing its 
-           library's attribute with the same name as the kernel name. The 
-           kernel function needs to be in a shared-object library that has 
-           been loaded by calling the load_library of the target device 
+           in the current stream.  The kernel is identified by accessing its
+           library's attribute with the same name as the kernel name. The
+           kernel function needs to be in a shared-object library that has
+           been loaded by calling the load_library of the target device
            before invoke.
 
            The additional arguments of invoke can be either instances
@@ -538,7 +538,7 @@ class OffloadStream:
 
            All operations (copy in/copy out and invocation) are enqueued into
            the stream object and complete asynchronously.
-           
+
            Parameters
            ----------
            kernel : kernel
@@ -560,7 +560,7 @@ class OffloadStream:
            >>> stream.invoke(library.dgemm, A, B, C, n, m, k)
         """
 
-        # if called from wrapper, actual arguments are wrapped in an 
+        # if called from wrapper, actual arguments are wrapped in an
         # extra tuple, so we unwrap them
         if len(args):
             if type(args[0]) == tuple:
@@ -571,7 +571,7 @@ class OffloadStream:
         if kernel[2] is not self._device:
             raise OffloadError("Cannot invoke kernel, "
                                "library not loaded on device")
-        
+
         # determine the types of the arguments (scalar vs arrays);
         # we store the device pointers as 64-bit integers in an ndarray
         arg_dims = numpy.empty((len(args),), dtype=numpy.int64)
@@ -597,7 +597,7 @@ class OffloadStream:
                 # and mark the numpy.ndarray for copyin/copyout semantics
                 host_ptr = a.ctypes.data # raw C pointer to host data
                 nbytes = a.dtype.itemsize * a.size
-                dev_ptr = self.allocate_device_memory(nbytes) 
+                dev_ptr = self.allocate_device_memory(nbytes)
                 copy_in_out.append((host_ptr, dev_ptr, nbytes, a))
                 arg_dims[i] = 1
                 arg_type[i] = map_data_types(a.dtype)
@@ -610,8 +610,8 @@ class OffloadStream:
                          kernel[0], i, host_ptr, dev_ptr))
             else:
                 # this is a hack, but let's wrap scalars as numpy arrays
-                cvtd = numpy.asarray(a) 
-                host_ptr = cvtd.ctypes.data  # raw C pointer to host data 
+                cvtd = numpy.asarray(a)
+                host_ptr = cvtd.ctypes.data  # raw C pointer to host data
                 nbytes = cvtd.dtype.itemsize * cvtd.size
                 scalars.append(cvtd)
                 arg_dims[i] = 0
@@ -624,13 +624,13 @@ class OffloadStream:
                          kernel[0], i, a, host_ptr))
         debug(1, "(device {0}, stream 0x{1:x}) invoking kernel '{2}' "
                  "(pointer 0x{3:x}) with {4} "
-                 "argument(s) ({5} copy-in/copy-out, {6} scalars)", 
-                 self._device_id, self._stream_id, kernel[0], kernel[1], 
+                 "argument(s) ({5} copy-in/copy-out, {6} scalars)",
+                 self._device_id, self._stream_id, kernel[0], kernel[1],
                  len(args), len(copy_in_out), len(scalars))
         # iterate over the copyin arguments and transfer them
         for c in copy_in_out:
             self.transfer_host2device(c[0], c[1], c[2])
-        pymic_stream_invoke_kernel(self._device_id, self._stream_id, kernel[1], 
+        pymic_stream_invoke_kernel(self._device_id, self._stream_id, kernel[1],
                                    len(args), arg_dims, arg_type, arg_ptrs,
                                    arg_size)
         # iterate over the copyout arguments, transfer them back,
@@ -639,7 +639,7 @@ class OffloadStream:
             self.transfer_device2host(c[1], c[0], c[2])
             self.deallocate_device_memory(c[1])
         return None
-        
+
     @trace
     def bind(self, array, update_device=True):
         """Create a new OffloadArray that is bound to an existing
@@ -648,8 +648,8 @@ class OffloadStream:
            Otherwise, the OffloadArray will be in unspecified state on
            the target device.  Data transfers to the host overwrite the
            data in the bound numpy.ndarray.
-           
-           The operation is enqueued into the stream object and completes 
+
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -691,7 +691,7 @@ class OffloadStream:
             raise ValueError("could not detect storage order")
 
         # construct and return a new OffloadArray
-        bound = pymic.OffloadArray(array.shape, array.dtype, order, False, 
+        bound = pymic.OffloadArray(array.shape, array.dtype, order, False,
                                    device=self._device, stream=self)
         bound.array = array
 
@@ -699,7 +699,7 @@ class OffloadStream:
         bound._device_ptr = self.allocate_device_memory(bound._nbytes)
         if update_device:
             bound.update_device()
-            
+
         return bound
 
     @trace
@@ -711,7 +711,7 @@ class OffloadStream:
            the target device.  Once the copy has been made, the original
            numpy.ndarray will not be modified by any data transfer operations.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -754,7 +754,7 @@ class OffloadStream:
 
         array_copy = numpy.empty_like(array)
         array_copy[:] = array[:]
-        return self.bind(array_copy, update_device, device=self._device, 
+        return self.bind(array_copy, update_device, device=self._device,
                          stream=self)
 
     @trace
@@ -765,7 +765,7 @@ class OffloadStream:
            the host numpy.ndarray.  If set to False, the data transfer is
            avoided and the data in the host array is in undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -804,7 +804,7 @@ class OffloadStream:
            array([[  4.26872718e-321,   6.92050581e-310],
                   [  4.34283703e-321,   6.92050581e-310]])  # random data
         """
-        array = pymic.OffloadArray(shape, dtype, order, device=self._device, 
+        array = pymic.OffloadArray(shape, dtype, order, device=self._device,
                                    stream=self)
         if update_host:
             array.update_host()
@@ -819,7 +819,7 @@ class OffloadStream:
            set to False, the data transfer is avoided and the data in the host
            array is in undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -850,11 +850,11 @@ class OffloadStream:
            array([[  4.26872718e-321,   6.95150287e-310],
                   [  4.34283703e-321,   6.95150287e-310]])  # random data
         """
-        if (not isinstance(other, numpy.ndarray) and 
+        if (not isinstance(other, numpy.ndarray) and
                 not isinstance(other, pymic.OffloadArray)):
             raise ValueError("only numpy.ndarray can be used "
                              "with this function")
-        return self.empty(other.shape, other.dtype, get_order(other), 
+        return self.empty(other.shape, other.dtype, get_order(other),
                           update_host=update_host)
 
     @trace
@@ -867,7 +867,7 @@ class OffloadStream:
            data transfer is avoided and the data in the host array is in
            undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -877,7 +877,7 @@ class OffloadStream:
            dtype       : data-type, optional
                Desired output data-type of the empty array
            order       : {'C', 'F'}, optional, default 'C'
-               Store multi-dimensional array data in row-major order 
+               Store multi-dimensional array data in row-major order
                (C/C++, 'C') or column-major order (Fortran, 'F')
            update_host : bool, optional, default True
                Control if the host array is updated with the array data
@@ -906,7 +906,7 @@ class OffloadStream:
            array([[ 0.,  0.],
                   [ 0.,  0.]])
         """
-        array = pymic.OffloadArray(shape, dtype, order, device=self._device, 
+        array = pymic.OffloadArray(shape, dtype, order, device=self._device,
                                    stream=self)
         array.zero()
         if update_host:
@@ -922,7 +922,7 @@ class OffloadStream:
            set to False, the data transfer is avoided and the data in the host
            array is in undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -958,11 +958,11 @@ class OffloadStream:
            array([[ 0.,  0.],
                   [ 0.,  0.]])
         """
-        if (not isinstance(other, numpy.ndarray) 
+        if (not isinstance(other, numpy.ndarray)
                 and not isinstance(other, pymic.OffloadArray)):
             raise ValueError("only numpy.ndarray can be used "
                              "with this function")
-        return self.zeros(other.shape, other.dtype, get_order(other), 
+        return self.zeros(other.shape, other.dtype, get_order(other),
                           update_host=update_host)
 
     @trace
@@ -975,7 +975,7 @@ class OffloadStream:
            data transfer is avoided and the data in the host array is in
            undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -985,7 +985,7 @@ class OffloadStream:
            dtype       : data-type, optional
                Desired output data-type of the empty array
            order       : {'C', 'F'}, optional, default 'C'
-               Store multi-dimensional array data in row-major order 
+               Store multi-dimensional array data in row-major order
                (C/C++, 'C') or column-major order (Fortran, 'F')
            update_host : bool, optional, default True
                Control if the host array is updated with the array data
@@ -1015,7 +1015,7 @@ class OffloadStream:
                   [ 1.,  1.]])
         """
 
-        array = pymic.OffloadArray(shape, dtype, order, device=self._device, 
+        array = pymic.OffloadArray(shape, dtype, order, device=self._device,
                                    stream=self)
         array.one()
         if update_host:
@@ -1031,7 +1031,7 @@ class OffloadStream:
            set to False, the data transfer is avoided and the data in the host
            array is in undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -1067,15 +1067,15 @@ class OffloadStream:
            array([[ 1.,  1.],
                   [ 1.,  1.]])
         """
-        if (not isinstance(other, numpy.ndarray) and 
+        if (not isinstance(other, numpy.ndarray) and
                 not isinstance(other, pymic.OffloadArray)):
             raise ValueError("only numpy.ndarray can be used "
                              "with this function")
-        return self.ones(other.shape, other.dtype, get_order(other), 
+        return self.ones(other.shape, other.dtype, get_order(other),
                          update_host=update_host)
 
     @trace
-    def bcast(self, value, shape, dtype=numpy.float, order='C', 
+    def bcast(self, value, shape, dtype=numpy.float, order='C',
               update_host=True):
         """Create a new OffloadArray that is bound to a numpy.ndarray
            of the given shape and data type, and that is initialized with all
@@ -1085,7 +1085,7 @@ class OffloadStream:
            False, the data transfer is avoided and the data in the host array
            is in undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -1097,7 +1097,7 @@ class OffloadStream:
            dtype       : data-type, optional
                Desired output data-type of the empty array
            order       : {'C', 'F'}, optional, default 'C'
-               Store multi-dimensional array data in row-major order 
+               Store multi-dimensional array data in row-major order
                (C/C++, 'C') or column-major order (Fortran, 'F')
            update_host : bool, optional, default True
                Control if the host array is updated with the array data
@@ -1127,7 +1127,7 @@ class OffloadStream:
            array([[ 42.,  42.],
                   [ 42.,  42.]])
         """
-        array = pymic.OffloadArray(shape, dtype, order, device=self._device, 
+        array = pymic.OffloadArray(shape, dtype, order, device=self._device,
                                    stream=self)
         array.fill(value)  # TODO: here the stream might become an issue
         if update_host:
@@ -1143,7 +1143,7 @@ class OffloadStream:
            set to False, the data transfer is avoided and the data in the host
            array is in undefined state.
 
-           The operation is enqueued into the stream object and completes 
+           The operation is enqueued into the stream object and completes
            asynchronously.
 
            Parameters
@@ -1181,27 +1181,27 @@ class OffloadStream:
            array([[ 42.,  42.],
                   [ 42.,  42.]])
         """
-        if (not isinstance(other, numpy.ndarray) and 
+        if (not isinstance(other, numpy.ndarray) and
                 not isinstance(other, pymic.OffloadArray)):
             raise ValueError("only numpy.ndarray can be used "
                              "with this function")
-        return self.bcast(value, other.shape, other.dtype, 
+        return self.bcast(value, other.shape, other.dtype,
                           get_order(other), update_host=update_host)
 
     def get_device(self):
         """Return the device this stream object is allocated for.
-        
+
            Parameters
            ----------
            n/a
-            
+
            Returns
            -------
-           OffloadStream : 
+           OffloadStream :
                Instance of the OffloadStream object.
 
            See Also
            --------
            n/a
-        """    
+        """
         return self._device


### PR DESCRIPTION
This request renames and refactors the FakePointer class, renaming it to DeviceAllocation.  It fixes various GC issues and enables the pointer translate method to be called.  (However, for other reasons I believe it is returning a bad pointer.)

Some trailing whitespace issues are also fixed.