### PR TITLE
Allow None to be passed to kernels.

### DIFF
--- a/pymic/offload_stream.py
+++ b/pymic/offload_stream.py
@@ -562,6 +562,9 @@ class OffloadStream:
             raise OffloadError("Cannot invoke kernel, "
                                "library not loaded on device")
 
+        # Map None to nullptr
+        args = [arg if arg is not None else 0 for arg in args]
+
         # determine the types of the arguments (scalar vs arrays);
         # we store the device pointers as 64-bit integers in an ndarray
         arg_dims = numpy.empty((len(args),), dtype=numpy.int64)


### PR DESCRIPTION
This request enables None to be passed to `invoke_kernel` where is it transparently mapped onto `0`.  This follows the convention that None in Python is equivalent to `nullptr` in C++.