### PR TITLE
Fixing error when dtype float32 numpy array is passed as kernel arg.

### DIFF
--- a/examples/double_float/Makefile
+++ b/examples/double_float/Makefile
@@ -1,0 +1,41 @@
+# Copyright (c) 2014-2016, Intel Corporation All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without 
+# modification, are permitted provided that the following conditions are 
+# met: 
+# 
+# 1. Redistributions of source code must retain the above copyright 
+# notice, this list of conditions and the following disclaimer. 
+#
+# 2. Redistributions in binary form must reproduce the above copyright 
+# notice, this list of conditions and the following disclaimer in the 
+# documentation and/or other materials provided with the distribution. 
+#
+# 3. Neither the name of the copyright holder nor the names of its 
+# contributors may be used to endorse or promote products derived from 
+# this software without specific prior written permission. 
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+.PHONY: all clean realclean
+ 
+all: libdouble_float.so
+
+libdouble_float.so: double_float.c
+	icc -fPIC -I../../include -shared -mmic -g -O2 -o $@ $<
+
+clean:
+	rm -f libdouble_float.so
+	
+realclean: clean
+	rm -f *~

--- a/examples/double_float/clean.bat
+++ b/examples/double_float/clean.bat
@@ -1,0 +1,32 @@
+@echo off
+
+REM # Copyright (c) 2014-2016, Intel Corporation All rights reserved.
+REM # 
+REM # Redistribution and use in source and binary forms, with or without 
+REM # modification, are permitted provided that the following conditions are 
+REM # met: 
+REM # 
+REM # 1. Redistributions of source code must retain the above copyright 
+REM # notice, this list of conditions and the following disclaimer. 
+REM #
+REM # 2. Redistributions in binary form must reproduce the above copyright 
+REM # notice, this list of conditions and the following disclaimer in the 
+REM # documentation and/or other materials provided with the distribution. 
+REM #
+REM # 3. Neither the name of the copyright holder nor the names of its 
+REM # contributors may be used to endorse or promote products derived from 
+REM # this software without specific prior written permission. 
+REM #
+REM # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+REM # IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+REM # TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+REM # PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+REM # HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+REM # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+REM # TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+REM # PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+REM # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+REM # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+REM # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+del *.so

--- a/examples/double_float/double_float.c
+++ b/examples/double_float/double_float.c
@@ -1,0 +1,39 @@
+/* Copyright (c) 2014-2016, Intel Corporation All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are 
+ * met: 
+ *
+ * 1. Redistributions of source code must retain the above copyright 
+ * notice, this list of conditions and the following disclaimer. 
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright 
+ * notice, this list of conditions and the following disclaimer in the 
+ * documentation and/or other materials provided with the distribution. 
+ *
+ * 3. Neither the name of the copyright holder nor the names of its 
+ * contributors may be used to endorse or promote products derived from 
+ * this software without specific prior written permission. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include <pymic_kernel.h>
+
+PYMIC_KERNEL
+void doubleit_kernel(float *array, const long int *n) {
+    int i;
+    for (i = 0; i < (*n); i++) {
+        array[i] *= 2.0;
+    }
+}

--- a/examples/double_float/double_float.py
+++ b/examples/double_float/double_float.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+
+# Copyright (c) 2014-2016, Intel Corporation All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+# IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+# TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import pymic as mic
+import numpy as np
+
+# load the library with the kernel function (on the target)
+print "device = mic.devices[0]"
+device = mic.devices[0]
+print "library = device.load_library...."
+library = device.load_library(("libdouble_float.so",))
+print "stream = device.get_d"
+stream = device.get_default_stream()
+
+na = np.arange(1, 33, dtype=np.float32)
+
+a = stream.bind(na)
+
+print "input:"
+print "--------------------------------------"
+print na
+print
+
+stream.invoke(library.doubleit_kernel, a, a.size)
+stream.sync()
+
+print "output:"
+print "--------------------------------------"
+a.update_host()
+stream.sync()
+print a

--- a/examples/double_float/make.bat
+++ b/examples/double_float/make.bat
@@ -1,0 +1,33 @@
+@echo off
+
+REM # Copyright (c) 2014-2016, Intel Corporation All rights reserved.
+REM # 
+REM # Redistribution and use in source and binary forms, with or without 
+REM # modification, are permitted provided that the following conditions are 
+REM # met: 
+REM # 
+REM # 1. Redistributions of source code must retain the above copyright 
+REM # notice, this list of conditions and the following disclaimer. 
+REM #
+REM # 2. Redistributions in binary form must reproduce the above copyright 
+REM # notice, this list of conditions and the following disclaimer in the 
+REM # documentation and/or other materials provided with the distribution. 
+REM #
+REM # 3. Neither the name of the copyright holder nor the names of its 
+REM # contributors may be used to endorse or promote products derived from 
+REM # this software without specific prior written permission. 
+REM #
+REM # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+REM # IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED 
+REM # TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+REM # PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+REM # HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+REM # SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED 
+REM # TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+REM # PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+REM # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+REM # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+REM # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+echo double_float.c
+icl -nologo -Qmic -I..\..\include -O2 -fPIC -shared -o libdouble_float.so double_float.c

--- a/pymic/_misc.py
+++ b/pymic/_misc.py
@@ -109,7 +109,8 @@ _data_type_map = {
     numpy.dtype(numpy.int32): 1,
     numpy.dtype(numpy.float64): 2,
     numpy.dtype(numpy.complex128): 3,
-    numpy.dtype(numpy.uint64): 4
+    numpy.dtype(numpy.uint64): 4,
+    numpy.dtype(numpy.float32): 5
 }
 
 

--- a/src/offload_array.c
+++ b/src/offload_array.c
@@ -40,9 +40,10 @@
 /* Data types, needs to match _data_type_map in _misc.py */
 #define DTYPE_INT64     0
 #define DTYPE_INT32     1
-#define DTYPE_FLOAT     2
+#define DTYPE_FLOAT64     2
 #define DTYPE_COMPLEX   3
 #define DTYPE_UINT64    4
+#define DTYPE_FLOAT32     5
 
 #define print printf
 
@@ -77,11 +78,21 @@ void pymic_offload_array_add(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             const double *x = (const double *)x_;
             const double *y = (const double *)y_;
             double *r = (double *)r_;
+            for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
+                r[ir] = x[ix] + y[iy];
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            const float *x = (const float *)x_;
+            const float *y = (const float *)y_;
+            float *r = (float *)r_;
             for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
                 r[ir] = x[ix] + y[iy];
             }
@@ -132,11 +143,21 @@ void pymic_offload_array_sub(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             const double *x = (const double *)x_;
             const double *y = (const double *)y_;
             double *r = (double *)r_;
+             for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
+                r[ir] = x[ix] - y[iy];
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            const float *x = (const float *)x_;
+            const float *y = (const float *)y_;
+            float *r = (float *)r_;
              for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
                 r[ir] = x[ix] - y[iy];
             }
@@ -186,11 +207,21 @@ void pymic_offload_array_mul(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             const double *x = (const double *)x_;
             const double *y = (const double *)y_;
             double *r = (double *)r_;
+            for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
+                r[ir] = x[ix] * y[iy];
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            const float *x = (const float *)x_;
+            const float *y = (const float *)y_;
+            float *r = (float *)r_;
             for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
                 r[ir] = x[ix] * y[iy];
             }
@@ -236,10 +267,19 @@ void pymic_offload_array_fill(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             double  *x  = (double *)ptr;
             double   v  = *(const double *)value;
+            for (i = 0; i < *n; i++) {
+                x[i] = v;
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            float  *x  = (float *)ptr;
+            float   v  = *(const float *)value;
             for (i = 0; i < *n; i++) {
                 x[i] = v;
             }
@@ -280,8 +320,11 @@ void pymic_offload_array_setslice(const int64_t *dtype,
     case DTYPE_INT32:
         scale = 4; /* bytes */
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         scale = 8; /* bytes */
+        break;
+    case DTYPE_FLOAT32:
+        scale = 4; /* bytes */
         break;
     case DTYPE_COMPLEX:
         scale = 16; /* bytes */
@@ -317,10 +360,19 @@ void pymic_offload_array_abs(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             const double *x = (const double *)x_;
             double *r = (double *)r_;
+            for (i = 0; i < *n; i++) {
+                r[i] = fabs(x[i]);
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            const float *x = (const float *)x_;
+            float *r = (float *)r_;
             for (i = 0; i < *n; i++) {
                 r[i] = fabs(x[i]);
             }
@@ -378,11 +430,22 @@ void pymic_offload_array_pow(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             const double *x = (const double *)x_;
             const double *y = (const double *)y_;
             double *r = (double *)r_;
+            i = ix = iy = ir = 0;
+            for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
+                r[ir] = pow(x[ix], y[iy]);
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            const float *x = (const float *)x_;
+            const float *y = (const float *)y_;
+            float *r = (float *)r_;
             i = ix = iy = ir = 0;
             for (; i < *n; i++, ix += *incx, iy += *incy, ir += *incr) {
                 r[ir] = pow(x[ix], y[iy]);
@@ -429,10 +492,19 @@ void pymic_offload_array_reverse(const int64_t *dtype, const int64_t *n,
             }
         }
         break;
-    case DTYPE_FLOAT:
+    case DTYPE_FLOAT64:
         {
             const double *x = (const double *)x_;
             double *r = (double *)r_;
+            for (i = 0; i < *n; i++) {
+                r[i] = x[*n - i - 1];
+            }
+        }
+        break;
+    case DTYPE_FLOAT32:
+        {
+            const float *x = (const float *)x_;
+            float *r = (float *)r_;
             for (i = 0; i < *n; i++) {
                 r[i] = x[*n - i - 1];
             }


### PR DESCRIPTION
Hi,

When I integrated pyMIC with one project I'm working on, I noticed the error below is thrown when I tried to pass a numpy array of float32 as an arg. 

  File "double_float.py", line 52, in <module>
    stream.invoke(library.doubleit_kernel, a, a.size)
  File "/scratch/felippe.vieira/pyMIC/build/lib.linux-x86_64-2.7/pymic/_tracing.py", line 128, in wrapper
    return func(*args, **kwargs)
  File "/scratch/felippe.vieira/pyMIC/build/lib.linux-x86_64-2.7/pymic/offload_stream.py", line 587, in invoke
    arg_type[i] = map_data_types(a.dtype)
  File "/scratch/felippe.vieira/pyMIC/build/lib.linux-x86_64-2.7/pymic/_misc.py", line 127, in _map_data_types
    return _data_type_map[dtype]
KeyError: dtype('float32')

The pull request add an example that reproduces the error on the current master branch and implements the commit that fix this issue.